### PR TITLE
API to get available free agents

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,3 +120,15 @@ Sample API Usage
     'position_type': 'P',
     'eligible_positions': ['RP'],
     'selected_position': 'RP'}]
+
+  In [14]: fa_CF = lg.free_agents('CF')
+
+  In [15]: len(fa_CF)
+  Out[15]: 60
+
+  In [11]: fa_CF[0]
+  Out[11]:
+  {'player_id': 8370,
+   'name': 'Dexter Fowler',
+   'position_type': 'B',
+   'eligible_positions': ['CF', 'RF', 'Util']}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 
 setup(name='yahoo_fantasy_api',
-      version='1.0.0',
+      version='1.1.0',
       description='Python bindings to access the Yahoo! Fantasy APIs',
       long_description=readme(),
       url='http://github.com/spilchen/yahoo_fantasy_api',

--- a/yahoo_fantasy_api/tests/mock_yhandler.py
+++ b/yahoo_fantasy_api/tests/mock_yhandler.py
@@ -80,3 +80,17 @@ class YHandler:
             fn = self.dir_path + "/sample.scoreboard.week12.json"
         with open(fn, "r") as f:
             return json.load(f)
+
+    def get_players_raw(self, league_id, start, status, position=None):
+        assert(position == "2B"), "Position must be 2B for mock"
+        assert(status == "A"), "FreeAgents only for mock"
+        if start == 0:
+            pg = "1"
+        elif start == 25:
+            pg = "2"
+        else:
+            pg = "3"
+        fn = self.dir_path + "/sample.players.freeagents.2B.pg.{}.json"\
+            .format(pg)
+        with open(fn, "r") as f:
+            return json.load(f)

--- a/yahoo_fantasy_api/tests/sample.players.freeagents.2B.pg.1.json
+++ b/yahoo_fantasy_api/tests/sample.players.freeagents.2B.pg.1.json
@@ -1,0 +1,2008 @@
+{
+    "fantasy_content": {
+        "xml:lang": "en-US",
+        "yahoo:uri": "/fantasy/v2/league/388.l.27081/players;start=0;count=25;status=A;position=2B",
+        "league": [
+            {
+                "league_key": "388.l.27081",
+                "league_id": "27081",
+                "name": "Buck you're next!",
+                "url": "https://baseball.fantasysports.yahoo.com/b1/27081",
+                "logo_url": false,
+                "draft_status": "postdraft",
+                "num_teams": 10,
+                "edit_key": "2019-08-26",
+                "weekly_deadline": "1",
+                "league_update_timestamp": "1566716592",
+                "scoring_type": "head",
+                "league_type": "private",
+                "renew": "378_2210",
+                "renewed": "",
+                "iris_group_chat_id": "ZP2QUJTUB5CPXMXWAVSYZRJI3Y",
+                "allow_add_to_dl_extra_pos": 0,
+                "is_pro_league": "0",
+                "is_cash_league": "0",
+                "current_week": 20,
+                "start_week": "1",
+                "start_date": "2019-03-20",
+                "end_week": "24",
+                "end_date": "2019-09-22",
+                "game_code": "mlb",
+                "season": "2019"
+            },
+            {
+                "players": {
+                    "0": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.7066"
+                                },
+                                {
+                                    "player_id": "7066"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Jos\u00e9 Reyes",
+                                        "first": "Jos\u00e9",
+                                        "last": "Reyes",
+                                        "ascii_first": "Jose",
+                                        "ascii_last": "Reyes"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.7066"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.21"
+                                },
+                                {
+                                    "editorial_team_full_name": "New York Mets"
+                                },
+                                {
+                                    "editorial_team_abbr": "NYM"
+                                },
+                                {
+                                    "uniform_number": "7"
+                                },
+                                {
+                                    "display_position": "2B,3B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/_lkIJ.Kg1NP6S9bH2iMSdg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03272018/7066.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/_lkIJ.Kg1NP6S9bH2iMSdg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03272018/7066.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "1": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.7313"
+                                },
+                                {
+                                    "player_id": "7313"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Andres Blanco",
+                                        "first": "Andres",
+                                        "last": "Blanco",
+                                        "ascii_first": "Andres",
+                                        "ascii_last": "Blanco"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.7313"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.15"
+                                },
+                                {
+                                    "editorial_team_full_name": "Atlanta Braves"
+                                },
+                                {
+                                    "editorial_team_abbr": "Atl"
+                                },
+                                {
+                                    "uniform_number": "88"
+                                },
+                                {
+                                    "display_position": "2B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/a28uY3aP0o1Awa8prBQiYg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04082019/7313.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/a28uY3aP0o1Awa8prBQiYg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04082019/7313.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "2": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.7490"
+                                },
+                                {
+                                    "player_id": "7490"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Ian Kinsler",
+                                        "first": "Ian",
+                                        "last": "Kinsler",
+                                        "ascii_first": "Ian",
+                                        "ascii_last": "Kinsler"
+                                    }
+                                },
+                                {
+                                    "status": "DL10",
+                                    "status_full": "10-Day Disabled List"
+                                },
+                                {
+                                    "on_disabled_list": "1"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.7490"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.25"
+                                },
+                                {
+                                    "editorial_team_full_name": "San Diego Padres"
+                                },
+                                {
+                                    "editorial_team_abbr": "SD"
+                                },
+                                {
+                                    "uniform_number": "3"
+                                },
+                                {
+                                    "display_position": "2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/rUDWr9euEsii6A9gyZ6mVQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/7490.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/rUDWr9euEsii6A9gyZ6mVQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/7490.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        },
+                                        {
+                                            "position": "DL"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1565975580
+                                }
+                            ]
+                        ]
+                    },
+                    "3": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.7497"
+                                },
+                                {
+                                    "player_id": "7497"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Robinson Can\u00f3",
+                                        "first": "Robinson",
+                                        "last": "Can\u00f3",
+                                        "ascii_first": "Robinson",
+                                        "ascii_last": "Cano"
+                                    }
+                                },
+                                {
+                                    "status": "DL10",
+                                    "status_full": "10-Day Disabled List"
+                                },
+                                {
+                                    "on_disabled_list": "1"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.7497"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.21"
+                                },
+                                {
+                                    "editorial_team_full_name": "New York Mets"
+                                },
+                                {
+                                    "editorial_team_abbr": "NYM"
+                                },
+                                {
+                                    "uniform_number": "24"
+                                },
+                                {
+                                    "display_position": "1B,2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/jYAXZHsq7RHeGVz96g4QKg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/7497.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/jYAXZHsq7RHeGVz96g4QKg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/7497.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        },
+                                        {
+                                            "position": "DL"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566418200
+                                }
+                            ]
+                        ]
+                    },
+                    "4": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.7631"
+                                },
+                                {
+                                    "player_id": "7631"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Dustin Pedroia",
+                                        "first": "Dustin",
+                                        "last": "Pedroia",
+                                        "ascii_first": "Dustin",
+                                        "ascii_last": "Pedroia"
+                                    }
+                                },
+                                {
+                                    "status": "DL60",
+                                    "status_full": "60-Day Disabled List"
+                                },
+                                {
+                                    "on_disabled_list": "1"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.7631"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.2"
+                                },
+                                {
+                                    "editorial_team_full_name": "Boston Red Sox"
+                                },
+                                {
+                                    "editorial_team_abbr": "Bos"
+                                },
+                                {
+                                    "uniform_number": "15"
+                                },
+                                {
+                                    "display_position": "2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/bblCcTA5eUYnP40lPVLLdw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04032019/7631.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/bblCcTA5eUYnP40lPVLLdw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04032019/7631.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        },
+                                        {
+                                            "position": "DL"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "5": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.7829"
+                                },
+                                {
+                                    "player_id": "7829"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Ben Zobrist",
+                                        "first": "Ben",
+                                        "last": "Zobrist",
+                                        "ascii_first": "Ben",
+                                        "ascii_last": "Zobrist"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.7829"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.16"
+                                },
+                                {
+                                    "editorial_team_full_name": "Chicago Cubs"
+                                },
+                                {
+                                    "editorial_team_abbr": "ChC"
+                                },
+                                {
+                                    "uniform_number": "18"
+                                },
+                                {
+                                    "display_position": "2B,LF,RF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/vCKKlVfNBBzi9T.ki4v0SA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03192018/7829.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/vCKKlVfNBBzi9T.ki4v0SA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03192018/7829.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "RF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566425880
+                                }
+                            ]
+                        ]
+                    },
+                    "6": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.7947"
+                                },
+                                {
+                                    "player_id": "7947"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Asdr\u00fabal Cabrera",
+                                        "first": "Asdr\u00fabal",
+                                        "last": "Cabrera",
+                                        "ascii_first": "Asdrubal",
+                                        "ascii_last": "Cabrera"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.7947"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.20"
+                                },
+                                {
+                                    "editorial_team_full_name": "Washington Nationals"
+                                },
+                                {
+                                    "editorial_team_abbr": "Was"
+                                },
+                                {
+                                    "uniform_number": "13"
+                                },
+                                {
+                                    "display_position": "2B,3B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/zLwGSVKkePBHA_Fm8WbfRQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/7947.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/zLwGSVKkePBHA_Fm8WbfRQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/7947.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566443100
+                                }
+                            ]
+                        ]
+                    },
+                    "7": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8112"
+                                },
+                                {
+                                    "player_id": "8112"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Emilio Bonifacio",
+                                        "first": "Emilio",
+                                        "last": "Bonifacio",
+                                        "ascii_first": "Emilio",
+                                        "ascii_last": "Bonifacio"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8112"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.30"
+                                },
+                                {
+                                    "editorial_team_full_name": "Tampa Bay Rays"
+                                },
+                                {
+                                    "editorial_team_abbr": "TB"
+                                },
+                                {
+                                    "uniform_number": "94"
+                                },
+                                {
+                                    "display_position": "2B,LF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/yy4lzAf994nneDyQPXbYZA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8112.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/yy4lzAf994nneDyQPXbYZA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8112.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "8": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8200"
+                                },
+                                {
+                                    "player_id": "8200"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Jed Lowrie",
+                                        "first": "Jed",
+                                        "last": "Lowrie",
+                                        "ascii_first": "Jed",
+                                        "ascii_last": "Lowrie"
+                                    }
+                                },
+                                {
+                                    "status": "DL60",
+                                    "status_full": "60-Day Disabled List"
+                                },
+                                {
+                                    "on_disabled_list": "1"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8200"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.21"
+                                },
+                                {
+                                    "editorial_team_full_name": "New York Mets"
+                                },
+                                {
+                                    "editorial_team_abbr": "NYM"
+                                },
+                                {
+                                    "uniform_number": "4"
+                                },
+                                {
+                                    "display_position": "2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/51GWyrtbgHHNF9g3Q6hOFA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8200.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/51GWyrtbgHHNF9g3Q6hOFA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8200.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        },
+                                        {
+                                            "position": "DL"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566332040
+                                }
+                            ]
+                        ]
+                    },
+                    "9": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8224"
+                                },
+                                {
+                                    "player_id": "8224"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Sean Rodr\u00edguez",
+                                        "first": "Sean",
+                                        "last": "Rodr\u00edguez",
+                                        "ascii_first": "Sean",
+                                        "ascii_last": "Rodriguez"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8224"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.22"
+                                },
+                                {
+                                    "editorial_team_full_name": "Philadelphia Phillies"
+                                },
+                                {
+                                    "editorial_team_abbr": "Phi"
+                                },
+                                {
+                                    "uniform_number": "13"
+                                },
+                                {
+                                    "display_position": "2B,3B,SS,LF,CF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/NtM2QHGlwTkyBXsTom0ktg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8224.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/NtM2QHGlwTkyBXsTom0ktg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8224.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "CF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "10": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8250"
+                                },
+                                {
+                                    "player_id": "8250"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Gregorio Petit",
+                                        "first": "Gregorio",
+                                        "last": "Petit",
+                                        "ascii_first": "Gregorio",
+                                        "ascii_last": "Petit"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8250"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.22"
+                                },
+                                {
+                                    "editorial_team_full_name": "Philadelphia Phillies"
+                                },
+                                {
+                                    "editorial_team_abbr": "Phi"
+                                },
+                                {
+                                    "uniform_number": "40"
+                                },
+                                {
+                                    "display_position": "2B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/ndV6JEcppswUqj3LnYI49A--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04102019/8250.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/ndV6JEcppswUqj3LnYI49A--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04102019/8250.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "11": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8314"
+                                },
+                                {
+                                    "player_id": "8314"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Daniel Murphy",
+                                        "first": "Daniel",
+                                        "last": "Murphy",
+                                        "ascii_first": "Daniel",
+                                        "ascii_last": "Murphy"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8314"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.27"
+                                },
+                                {
+                                    "editorial_team_full_name": "Colorado Rockies"
+                                },
+                                {
+                                    "editorial_team_abbr": "Col"
+                                },
+                                {
+                                    "uniform_number": "9"
+                                },
+                                {
+                                    "display_position": "1B,2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/4pQ.RHNbJeac7Y19pWzjQA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8314.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/4pQ.RHNbJeac7Y19pWzjQA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8314.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1565996340
+                                }
+                            ]
+                        ]
+                    },
+                    "12": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8422"
+                                },
+                                {
+                                    "player_id": "8422"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Gordon Beckham",
+                                        "first": "Gordon",
+                                        "last": "Beckham",
+                                        "ascii_first": "Gordon",
+                                        "ascii_last": "Beckham"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8422"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.6"
+                                },
+                                {
+                                    "editorial_team_full_name": "Detroit Tigers"
+                                },
+                                {
+                                    "editorial_team_abbr": "Det"
+                                },
+                                {
+                                    "uniform_number": "29"
+                                },
+                                {
+                                    "display_position": "2B,3B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/J4Wtptu9JRoxDxE9wUCIjg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03252019/8422.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/J4Wtptu9JRoxDxE9wUCIjg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03252019/8422.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "13": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8571"
+                                },
+                                {
+                                    "player_id": "8571"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Neil Walker",
+                                        "first": "Neil",
+                                        "last": "Walker",
+                                        "ascii_first": "Neil",
+                                        "ascii_last": "Walker"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8571"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.28"
+                                },
+                                {
+                                    "editorial_team_full_name": "Miami Marlins"
+                                },
+                                {
+                                    "editorial_team_abbr": "Mia"
+                                },
+                                {
+                                    "uniform_number": "18"
+                                },
+                                {
+                                    "display_position": "1B,2B,3B,RF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/L6OqYih55bMiT5vzakqs8g--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03242019/8571.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/L6OqYih55bMiT5vzakqs8g--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03242019/8571.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "RF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1565986800
+                                }
+                            ]
+                        ]
+                    },
+                    "14": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8611"
+                                },
+                                {
+                                    "player_id": "8611"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Starlin Castro",
+                                        "first": "Starlin",
+                                        "last": "Castro",
+                                        "ascii_first": "Starlin",
+                                        "ascii_last": "Castro"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8611"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.28"
+                                },
+                                {
+                                    "editorial_team_full_name": "Miami Marlins"
+                                },
+                                {
+                                    "editorial_team_abbr": "Mia"
+                                },
+                                {
+                                    "uniform_number": "13"
+                                },
+                                {
+                                    "display_position": "2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/9QtV3ywL2m522djLi8a77w--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/05022019/8611.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/9QtV3ywL2m522djLi8a77w--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/05022019/8611.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566617820
+                                }
+                            ]
+                        ]
+                    },
+                    "15": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8628"
+                                },
+                                {
+                                    "player_id": "8628"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Zack Cozart",
+                                        "first": "Zack",
+                                        "last": "Cozart",
+                                        "ascii_first": "Zack",
+                                        "ascii_last": "Cozart"
+                                    }
+                                },
+                                {
+                                    "status": "DL60",
+                                    "status_full": "60-Day Disabled List"
+                                },
+                                {
+                                    "on_disabled_list": "1"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8628"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.3"
+                                },
+                                {
+                                    "editorial_team_full_name": "Los Angeles Angels"
+                                },
+                                {
+                                    "editorial_team_abbr": "LAA"
+                                },
+                                {
+                                    "uniform_number": "7"
+                                },
+                                {
+                                    "display_position": "2B,3B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/MVhsDphQ_G1_qZNN9QPrNQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04182019/8628.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/MVhsDphQ_G1_qZNN9QPrNQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04182019/8628.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        },
+                                        {
+                                            "position": "DL"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "16": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8691"
+                                },
+                                {
+                                    "player_id": "8691"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Tim Beckham",
+                                        "first": "Tim",
+                                        "last": "Beckham",
+                                        "ascii_first": "Tim",
+                                        "ascii_last": "Beckham"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8691"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.12"
+                                },
+                                {
+                                    "editorial_team_full_name": "Seattle Mariners"
+                                },
+                                {
+                                    "editorial_team_abbr": "Sea"
+                                },
+                                {
+                                    "uniform_number": "1"
+                                },
+                                {
+                                    "display_position": "2B,3B,SS,LF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/8Z2y8yfnyw9k6e5otjdzUg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04292019/8691.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/8Z2y8yfnyw9k6e5otjdzUg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04292019/8691.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "17": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8787"
+                                },
+                                {
+                                    "player_id": "8787"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Darwin Barney",
+                                        "first": "Darwin",
+                                        "last": "Barney",
+                                        "ascii_first": "Darwin",
+                                        "ascii_last": "Barney"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8787"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.13"
+                                },
+                                {
+                                    "editorial_team_full_name": "Texas Rangers"
+                                },
+                                {
+                                    "editorial_team_abbr": "Tex"
+                                },
+                                {
+                                    "uniform_number": "20"
+                                },
+                                {
+                                    "display_position": "2B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/9_ub8QS5skcvEMWRW4OVtg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03132018/8787.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/9_ub8QS5skcvEMWRW4OVtg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03132018/8787.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "18": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8789"
+                                },
+                                {
+                                    "player_id": "8789"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Eduardo N\u00fa\u00f1ez",
+                                        "first": "Eduardo",
+                                        "last": "N\u00fa\u00f1ez",
+                                        "ascii_first": "Eduardo",
+                                        "ascii_last": "Nunez"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8789"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.2"
+                                },
+                                {
+                                    "editorial_team_full_name": "Boston Red Sox"
+                                },
+                                {
+                                    "editorial_team_abbr": "Bos"
+                                },
+                                {
+                                    "uniform_number": "36"
+                                },
+                                {
+                                    "display_position": "2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/H3U9oFKUrHaBDmQSfIxvfg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04032019/8789.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/H3U9oFKUrHaBDmQSfIxvfg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04032019/8789.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "19": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8828"
+                                },
+                                {
+                                    "player_id": "8828"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Eric Sogard",
+                                        "first": "Eric",
+                                        "last": "Sogard",
+                                        "ascii_first": "Eric",
+                                        "ascii_last": "Sogard"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8828"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.30"
+                                },
+                                {
+                                    "editorial_team_full_name": "Tampa Bay Rays"
+                                },
+                                {
+                                    "editorial_team_abbr": "TB"
+                                },
+                                {
+                                    "uniform_number": "9"
+                                },
+                                {
+                                    "display_position": "2B,SS,RF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/LAJh3U92z.B.f19ry03jxQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03242019/8828.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/LAJh3U92z.B.f19ry03jxQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03242019/8828.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "RF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566095880
+                                }
+                            ]
+                        ]
+                    },
+                    "20": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8831"
+                                },
+                                {
+                                    "player_id": "8831"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Daniel Descalso",
+                                        "first": "Daniel",
+                                        "last": "Descalso",
+                                        "ascii_first": "Daniel",
+                                        "ascii_last": "Descalso"
+                                    }
+                                },
+                                {
+                                    "status": "DL10",
+                                    "status_full": "10-Day Disabled List"
+                                },
+                                {
+                                    "on_disabled_list": "1"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8831"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.16"
+                                },
+                                {
+                                    "editorial_team_full_name": "Chicago Cubs"
+                                },
+                                {
+                                    "editorial_team_abbr": "ChC"
+                                },
+                                {
+                                    "uniform_number": "3"
+                                },
+                                {
+                                    "display_position": "1B,2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/3SGcleEC1tu2pSdnlnjeIQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8831.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/3SGcleEC1tu2pSdnlnjeIQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8831.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        },
+                                        {
+                                            "position": "DL"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1565991960
+                                }
+                            ]
+                        ]
+                    },
+                    "21": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8842"
+                                },
+                                {
+                                    "player_id": "8842"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Andrew Romine",
+                                        "first": "Andrew",
+                                        "last": "Romine",
+                                        "ascii_first": "Andrew",
+                                        "ascii_last": "Romine"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8842"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.22"
+                                },
+                                {
+                                    "editorial_team_full_name": "Philadelphia Phillies"
+                                },
+                                {
+                                    "editorial_team_abbr": "Phi"
+                                },
+                                {
+                                    "uniform_number": "28"
+                                },
+                                {
+                                    "display_position": "1B,2B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/evsmdAqx8J96NBcvai84yg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8842.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/evsmdAqx8J96NBcvai84yg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8842.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "22": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8853"
+                                },
+                                {
+                                    "player_id": "8853"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Jason Kipnis",
+                                        "first": "Jason",
+                                        "last": "Kipnis",
+                                        "ascii_first": "Jason",
+                                        "ascii_last": "Kipnis"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8853"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.5"
+                                },
+                                {
+                                    "editorial_team_full_name": "Cleveland Indians"
+                                },
+                                {
+                                    "editorial_team_abbr": "Cle"
+                                },
+                                {
+                                    "uniform_number": "22"
+                                },
+                                {
+                                    "display_position": "2B,CF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/V4XL.o_ZeR.i88P1oMfe.Q--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04122019/8853.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/V4XL.o_ZeR.i88P1oMfe.Q--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04122019/8853.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "CF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566352500
+                                }
+                            ]
+                        ]
+                    },
+                    "23": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8863"
+                                },
+                                {
+                                    "player_id": "8863"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Dee Gordon",
+                                        "first": "Dee",
+                                        "last": "Gordon",
+                                        "ascii_first": "Dee",
+                                        "ascii_last": "Gordon"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8863"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.12"
+                                },
+                                {
+                                    "editorial_team_full_name": "Seattle Mariners"
+                                },
+                                {
+                                    "editorial_team_abbr": "Sea"
+                                },
+                                {
+                                    "uniform_number": "9"
+                                },
+                                {
+                                    "display_position": "2B,SS,CF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/FG0gkXqt1BK1p77ft44ojQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04292019/8863.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/FG0gkXqt1BK1p77ft44ojQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04292019/8863.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "CF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566138420
+                                }
+                            ]
+                        ]
+                    },
+                    "24": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8866"
+                                },
+                                {
+                                    "player_id": "8866"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Grant Green",
+                                        "first": "Grant",
+                                        "last": "Green",
+                                        "ascii_first": "Grant",
+                                        "ascii_last": "Green"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8866"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.28"
+                                },
+                                {
+                                    "editorial_team_full_name": "Miami Marlins"
+                                },
+                                {
+                                    "editorial_team_abbr": "Mia"
+                                },
+                                {
+                                    "uniform_number": "5"
+                                },
+                                {
+                                    "display_position": "2B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/MMzhJwrcT5BqJGpKnnfKtw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/10162017/8866.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/MMzhJwrcT5BqJGpKnnfKtw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/10162017/8866.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "count": 25
+                }
+            }
+        ],
+        "time": "56.807041168213ms",
+        "copyright": "Data provided by Yahoo! and STATS, LLC",
+        "refresh_rate": "60"
+    }
+}

--- a/yahoo_fantasy_api/tests/sample.players.freeagents.2B.pg.2.json
+++ b/yahoo_fantasy_api/tests/sample.players.freeagents.2B.pg.2.json
@@ -1,0 +1,1936 @@
+{
+    "fantasy_content": {
+        "xml:lang": "en-US",
+        "yahoo:uri": "/fantasy/v2/league/388.l.27081/players;start=25;count=25;status=A;position=2B",
+        "league": [
+            {
+                "league_key": "388.l.27081",
+                "league_id": "27081",
+                "name": "Buck you're next!",
+                "url": "https://baseball.fantasysports.yahoo.com/b1/27081",
+                "logo_url": false,
+                "draft_status": "postdraft",
+                "num_teams": 10,
+                "edit_key": "2019-08-26",
+                "weekly_deadline": "1",
+                "league_update_timestamp": "1566716592",
+                "scoring_type": "head",
+                "league_type": "private",
+                "renew": "378_2210",
+                "renewed": "",
+                "iris_group_chat_id": "ZP2QUJTUB5CPXMXWAVSYZRJI3Y",
+                "allow_add_to_dl_extra_pos": 0,
+                "is_pro_league": "0",
+                "is_cash_league": "0",
+                "current_week": 20,
+                "start_week": "1",
+                "start_date": "2019-03-20",
+                "end_week": "24",
+                "end_date": "2019-09-22",
+                "game_code": "mlb",
+                "season": "2019"
+            },
+            {
+                "players": {
+                    "0": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8887"
+                                },
+                                {
+                                    "player_id": "8887"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Michael Mart\u00ednez",
+                                        "first": "Michael",
+                                        "last": "Mart\u00ednez",
+                                        "ascii_first": "Michael",
+                                        "ascii_last": "Martinez"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8887"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.5"
+                                },
+                                {
+                                    "editorial_team_full_name": "Cleveland Indians"
+                                },
+                                {
+                                    "editorial_team_abbr": "Cle"
+                                },
+                                {
+                                    "uniform_number": "2"
+                                },
+                                {
+                                    "display_position": "2B,RF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/Y0r9x2vqfM6l4k5X6XwWyA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/10162017/8887.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/Y0r9x2vqfM6l4k5X6XwWyA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/10162017/8887.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "RF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "1": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8921"
+                                },
+                                {
+                                    "player_id": "8921"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Logan Forsythe",
+                                        "first": "Logan",
+                                        "last": "Forsythe",
+                                        "ascii_first": "Logan",
+                                        "ascii_last": "Forsythe"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8921"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.13"
+                                },
+                                {
+                                    "editorial_team_full_name": "Texas Rangers"
+                                },
+                                {
+                                    "editorial_team_abbr": "Tex"
+                                },
+                                {
+                                    "uniform_number": "41"
+                                },
+                                {
+                                    "display_position": "1B,2B,3B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/Zw7EjUkzK8WNDUkEQqVKfg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/05162019/8921.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/Zw7EjUkzK8WNDUkEQqVKfg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/05162019/8921.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "2": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8950"
+                                },
+                                {
+                                    "player_id": "8950"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Josh Harrison",
+                                        "first": "Josh",
+                                        "last": "Harrison",
+                                        "ascii_first": "Josh",
+                                        "ascii_last": "Harrison"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8950"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.6"
+                                },
+                                {
+                                    "editorial_team_full_name": "Detroit Tigers"
+                                },
+                                {
+                                    "editorial_team_abbr": "Det"
+                                },
+                                {
+                                    "uniform_number": "1"
+                                },
+                                {
+                                    "display_position": "2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/pG9t6XQawVQ0dN_IrApZvQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03252019/8950.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/pG9t6XQawVQ0dN_IrApZvQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03252019/8950.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "3": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8953"
+                                },
+                                {
+                                    "player_id": "8953"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Matt Carpenter",
+                                        "first": "Matt",
+                                        "last": "Carpenter",
+                                        "ascii_first": "Matt",
+                                        "ascii_last": "Carpenter"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8953"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.24"
+                                },
+                                {
+                                    "editorial_team_full_name": "St. Louis Cardinals"
+                                },
+                                {
+                                    "editorial_team_abbr": "StL"
+                                },
+                                {
+                                    "uniform_number": "13"
+                                },
+                                {
+                                    "display_position": "1B,2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/amgdvnSRlJkESdyHvnutGw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04082019/8953.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/amgdvnSRlJkESdyHvnutGw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04082019/8953.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566678900
+                                }
+                            ]
+                        ]
+                    },
+                    "4": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.8974"
+                                },
+                                {
+                                    "player_id": "8974"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Chase d'Arnaud",
+                                        "first": "Chase",
+                                        "last": "d'Arnaud",
+                                        "ascii_first": "Chase",
+                                        "ascii_last": "d'Arnaud"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.8974"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.13"
+                                },
+                                {
+                                    "editorial_team_full_name": "Texas Rangers"
+                                },
+                                {
+                                    "editorial_team_abbr": "Tex"
+                                },
+                                {
+                                    "uniform_number": "6"
+                                },
+                                {
+                                    "display_position": "2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/BsEoFQJezbCPNZNDLR1YGQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8974.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/BsEoFQJezbCPNZNDLR1YGQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/8974.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "5": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9038"
+                                },
+                                {
+                                    "player_id": "9038"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Steve Lombardozzi",
+                                        "first": "Steve",
+                                        "last": "Lombardozzi",
+                                        "ascii_first": "Steve",
+                                        "ascii_last": "Lombardozzi"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9038"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.11"
+                                },
+                                {
+                                    "editorial_team_full_name": "Oakland Athletics"
+                                },
+                                {
+                                    "editorial_team_abbr": "Oak"
+                                },
+                                {
+                                    "uniform_number": "21"
+                                },
+                                {
+                                    "display_position": "2B,LF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/kQqan.WlIXzHemR4uJLl7Q--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03122018/9038.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/kQqan.WlIXzHemR4uJLl7Q--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03122018/9038.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "6": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9102"
+                                },
+                                {
+                                    "player_id": "9102"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Cory Spangenberg",
+                                        "first": "Cory",
+                                        "last": "Spangenberg",
+                                        "ascii_first": "Cory",
+                                        "ascii_last": "Spangenberg"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9102"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.8"
+                                },
+                                {
+                                    "editorial_team_full_name": "Milwaukee Brewers"
+                                },
+                                {
+                                    "editorial_team_abbr": "Mil"
+                                },
+                                {
+                                    "uniform_number": "5"
+                                },
+                                {
+                                    "display_position": "2B,3B,LF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/Ie0yqoflJz5Q2HqghTB77A--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9102.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/Ie0yqoflJz5Q2HqghTB77A--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9102.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566672600
+                                }
+                            ]
+                        ]
+                    },
+                    "7": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9103"
+                                },
+                                {
+                                    "player_id": "9103"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Kolten Wong",
+                                        "first": "Kolten",
+                                        "last": "Wong",
+                                        "ascii_first": "Kolten",
+                                        "ascii_last": "Wong"
+                                    }
+                                },
+                                {
+                                    "status": "DTD",
+                                    "status_full": "Day-to-Day"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9103"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.24"
+                                },
+                                {
+                                    "editorial_team_full_name": "St. Louis Cardinals"
+                                },
+                                {
+                                    "editorial_team_abbr": "StL"
+                                },
+                                {
+                                    "uniform_number": "16"
+                                },
+                                {
+                                    "display_position": "2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/iDIsW9iBaatS3bRQWGPSxw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04042018/9103.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/iDIsW9iBaatS3bRQWGPSxw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04042018/9103.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                {
+                                    "has_recent_player_notes": 1
+                                },
+                                {
+                                    "player_notes_last_timestamp": 1566742380
+                                }
+                            ]
+                        ]
+                    },
+                    "8": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9104"
+                                },
+                                {
+                                    "player_id": "9104"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Jonathan Schoop",
+                                        "first": "Jonathan",
+                                        "last": "Schoop",
+                                        "ascii_first": "Jonathan",
+                                        "ascii_last": "Schoop"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9104"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.9"
+                                },
+                                {
+                                    "editorial_team_full_name": "Minnesota Twins"
+                                },
+                                {
+                                    "editorial_team_abbr": "Min"
+                                },
+                                {
+                                    "uniform_number": "16"
+                                },
+                                {
+                                    "display_position": "2B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/tJ5EFhwj0eBYT3T01xRuhw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9104.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/tJ5EFhwj0eBYT3T01xRuhw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9104.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                {
+                                    "has_recent_player_notes": 1
+                                },
+                                {
+                                    "player_notes_last_timestamp": 1566767520
+                                }
+                            ]
+                        ]
+                    },
+                    "9": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9107"
+                                },
+                                {
+                                    "player_id": "9107"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Jedd Gyorko",
+                                        "first": "Jedd",
+                                        "last": "Gyorko",
+                                        "ascii_first": "Jedd",
+                                        "ascii_last": "Gyorko"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9107"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.19"
+                                },
+                                {
+                                    "editorial_team_full_name": "Los Angeles Dodgers"
+                                },
+                                {
+                                    "editorial_team_abbr": "LAD"
+                                },
+                                {
+                                    "uniform_number": "26"
+                                },
+                                {
+                                    "display_position": "2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/eXq.h8kjPBRE6v4diLNUYQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04082019/9107.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/eXq.h8kjPBRE6v4diLNUYQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04082019/9107.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566138300
+                                }
+                            ]
+                        ]
+                    },
+                    "10": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9112"
+                                },
+                                {
+                                    "player_id": "9112"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Jurickson Profar",
+                                        "first": "Jurickson",
+                                        "last": "Profar",
+                                        "ascii_first": "Jurickson",
+                                        "ascii_last": "Profar"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9112"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.11"
+                                },
+                                {
+                                    "editorial_team_full_name": "Oakland Athletics"
+                                },
+                                {
+                                    "editorial_team_abbr": "Oak"
+                                },
+                                {
+                                    "uniform_number": "23"
+                                },
+                                {
+                                    "display_position": "1B,2B,3B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/9NwfUp9PRDGosyuSNfOBow--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9112.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/9NwfUp9PRDGosyuSNfOBow--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9112.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "11": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9115"
+                                },
+                                {
+                                    "player_id": "9115"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Nick Franklin",
+                                        "first": "Nick",
+                                        "last": "Franklin",
+                                        "ascii_first": "Nick",
+                                        "ascii_last": "Franklin"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9115"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.23"
+                                },
+                                {
+                                    "editorial_team_full_name": "Pittsburgh Pirates"
+                                },
+                                {
+                                    "editorial_team_abbr": "Pit"
+                                },
+                                {
+                                    "uniform_number": "67"
+                                },
+                                {
+                                    "display_position": "2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/rrgCken.g5MpKn_zNKNavQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9115.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/rrgCken.g5MpKn_zNKNavQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9115.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "12": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9142"
+                                },
+                                {
+                                    "player_id": "9142"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Marwin Gonzalez",
+                                        "first": "Marwin",
+                                        "last": "Gonzalez",
+                                        "ascii_first": "Marwin",
+                                        "ascii_last": "Gonzalez"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9142"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.9"
+                                },
+                                {
+                                    "editorial_team_full_name": "Minnesota Twins"
+                                },
+                                {
+                                    "editorial_team_abbr": "Min"
+                                },
+                                {
+                                    "uniform_number": "9"
+                                },
+                                {
+                                    "display_position": "1B,2B,3B,SS,LF,RF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/b.QAesoHXHQuP0wmUFxX.w--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9142.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/b.QAesoHXHQuP0wmUFxX.w--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9142.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "RF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1565933880
+                                }
+                            ]
+                        ]
+                    },
+                    "13": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9174"
+                                },
+                                {
+                                    "player_id": "9174"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Brian Dozier",
+                                        "first": "Brian",
+                                        "last": "Dozier",
+                                        "ascii_first": "Brian",
+                                        "ascii_last": "Dozier"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9174"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.20"
+                                },
+                                {
+                                    "editorial_team_full_name": "Washington Nationals"
+                                },
+                                {
+                                    "editorial_team_abbr": "Was"
+                                },
+                                {
+                                    "uniform_number": "9"
+                                },
+                                {
+                                    "display_position": "2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/u4QDw_ytxkAmQMYmig2qKg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04102019/9174.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/u4QDw_ytxkAmQMYmig2qKg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04102019/9174.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566504840
+                                }
+                            ]
+                        ]
+                    },
+                    "14": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9183"
+                                },
+                                {
+                                    "player_id": "9183"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Charlie Culberson",
+                                        "first": "Charlie",
+                                        "last": "Culberson",
+                                        "ascii_first": "Charlie",
+                                        "ascii_last": "Culberson"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9183"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.15"
+                                },
+                                {
+                                    "editorial_team_full_name": "Atlanta Braves"
+                                },
+                                {
+                                    "editorial_team_abbr": "Atl"
+                                },
+                                {
+                                    "uniform_number": "8"
+                                },
+                                {
+                                    "display_position": "2B,3B,SS,LF,RF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/EMTwjwdGTHdFGonxpFIW2w--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04082019/9183.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/EMTwjwdGTHdFGonxpFIW2w--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04082019/9183.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "RF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "15": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9190"
+                                },
+                                {
+                                    "player_id": "9190"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Donovan Solano",
+                                        "first": "Donovan",
+                                        "last": "Solano",
+                                        "ascii_first": "Donovan",
+                                        "ascii_last": "Solano"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9190"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.26"
+                                },
+                                {
+                                    "editorial_team_full_name": "San Francisco Giants"
+                                },
+                                {
+                                    "editorial_team_abbr": "SF"
+                                },
+                                {
+                                    "uniform_number": "7"
+                                },
+                                {
+                                    "display_position": "2B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/7aBUW6oKzUim.Lpfc8lhQA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04232019/9190.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/7aBUW6oKzUim.Lpfc8lhQA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04232019/9190.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "16": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9213"
+                                },
+                                {
+                                    "player_id": "9213"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Hern\u00e1n P\u00e9rez",
+                                        "first": "Hern\u00e1n",
+                                        "last": "P\u00e9rez",
+                                        "ascii_first": "Hernan",
+                                        "ascii_last": "Perez"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9213"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.8"
+                                },
+                                {
+                                    "editorial_team_full_name": "Milwaukee Brewers"
+                                },
+                                {
+                                    "editorial_team_abbr": "Mil"
+                                },
+                                {
+                                    "uniform_number": "14"
+                                },
+                                {
+                                    "display_position": "2B,3B,SS,LF,RF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/aX.9CtiBSxLHF_c_UWdxMQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04162019/9213.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/aX.9CtiBSxLHF_c_UWdxMQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04162019/9213.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "RF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "17": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9237"
+                                },
+                                {
+                                    "player_id": "9237"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Josh Rutledge",
+                                        "first": "Josh",
+                                        "last": "Rutledge",
+                                        "ascii_first": "Josh",
+                                        "ascii_last": "Rutledge"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9237"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.26"
+                                },
+                                {
+                                    "editorial_team_full_name": "San Francisco Giants"
+                                },
+                                {
+                                    "editorial_team_abbr": "SF"
+                                },
+                                {
+                                    "uniform_number": "19"
+                                },
+                                {
+                                    "display_position": "2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/xMsXy3qHoAqFBkkxmLtfOg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03082018/9237.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/xMsXy3qHoAqFBkkxmLtfOg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03082018/9237.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "18": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9259"
+                                },
+                                {
+                                    "player_id": "9259"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Adeiny Hechavarr\u00eda",
+                                        "first": "Adeiny",
+                                        "last": "Hechavarr\u00eda",
+                                        "ascii_first": "Adeiny",
+                                        "ascii_last": "Hechavarria"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9259"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.15"
+                                },
+                                {
+                                    "editorial_team_full_name": "Atlanta Braves"
+                                },
+                                {
+                                    "editorial_team_abbr": "Atl"
+                                },
+                                {
+                                    "uniform_number": "24"
+                                },
+                                {
+                                    "display_position": "2B,3B,SS"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/Hr6tyyknDVJKoiaAzcj40w--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9259.1.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/Hr6tyyknDVJKoiaAzcj40w--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03222019/9259.1.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1565983140
+                                }
+                            ]
+                        ]
+                    },
+                    "19": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9292"
+                                },
+                                {
+                                    "player_id": "9292"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Brock Holt",
+                                        "first": "Brock",
+                                        "last": "Holt",
+                                        "ascii_first": "Brock",
+                                        "ascii_last": "Holt"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9292"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.2"
+                                },
+                                {
+                                    "editorial_team_full_name": "Boston Red Sox"
+                                },
+                                {
+                                    "editorial_team_abbr": "Bos"
+                                },
+                                {
+                                    "uniform_number": "12"
+                                },
+                                {
+                                    "display_position": "2B,SS,RF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/6u7WGOENpBQx_QUelvaJhg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04032019/9292.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/6u7WGOENpBQx_QUelvaJhg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04032019/9292.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "RF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                {
+                                    "has_recent_player_notes": 1
+                                },
+                                {
+                                    "player_notes_last_timestamp": 1566707760
+                                }
+                            ]
+                        ]
+                    },
+                    "20": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9324"
+                                },
+                                {
+                                    "player_id": "9324"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Kaleb Cowart",
+                                        "first": "Kaleb",
+                                        "last": "Cowart",
+                                        "ascii_first": "Kaleb",
+                                        "ascii_last": "Cowart"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9324"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.3"
+                                },
+                                {
+                                    "editorial_team_full_name": "Los Angeles Angels"
+                                },
+                                {
+                                    "editorial_team_abbr": "LAA"
+                                },
+                                {
+                                    "uniform_number": "22"
+                                },
+                                {
+                                    "display_position": "2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/XtMKEBaCy655Gk_L7GVyYw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04182019/9324.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/XtMKEBaCy655Gk_L7GVyYw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04182019/9324.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "21": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9387"
+                                },
+                                {
+                                    "player_id": "9387"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Corban Joseph",
+                                        "first": "Corban",
+                                        "last": "Joseph",
+                                        "ascii_first": "Corban",
+                                        "ascii_last": "Joseph"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9387"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.11"
+                                },
+                                {
+                                    "editorial_team_full_name": "Oakland Athletics"
+                                },
+                                {
+                                    "editorial_team_abbr": "Oak"
+                                },
+                                {
+                                    "uniform_number": "56"
+                                },
+                                {
+                                    "display_position": "2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/5cSClUU4TKIzbgE9mrMHXA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04152019/9387.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/5cSClUU4TKIzbgE9mrMHXA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04152019/9387.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "22": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9391"
+                                },
+                                {
+                                    "player_id": "9391"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Derek Dietrich",
+                                        "first": "Derek",
+                                        "last": "Dietrich",
+                                        "ascii_first": "Derek",
+                                        "ascii_last": "Dietrich"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9391"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.17"
+                                },
+                                {
+                                    "editorial_team_full_name": "Cincinnati Reds"
+                                },
+                                {
+                                    "editorial_team_abbr": "Cin"
+                                },
+                                {
+                                    "uniform_number": "22"
+                                },
+                                {
+                                    "display_position": "1B,2B,LF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/sVhUcgmUnnfgjtTm4PNEhw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03242019/9391.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/sVhUcgmUnnfgjtTm4PNEhw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/03242019/9391.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566583800
+                                }
+                            ]
+                        ]
+                    },
+                    "23": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9411"
+                                },
+                                {
+                                    "player_id": "9411"
+                                },
+                                {
+                                    "name": {
+                                        "full": "C\u00e9sar Hern\u00e1ndez",
+                                        "first": "C\u00e9sar",
+                                        "last": "Hern\u00e1ndez",
+                                        "ascii_first": "Cesar",
+                                        "ascii_last": "Hernandez"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9411"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.22"
+                                },
+                                {
+                                    "editorial_team_full_name": "Philadelphia Phillies"
+                                },
+                                {
+                                    "editorial_team_abbr": "Phi"
+                                },
+                                {
+                                    "uniform_number": "16"
+                                },
+                                {
+                                    "display_position": "2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/SATLmmyD.Ui2FbBTzdBIEg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04102019/9411.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/SATLmmyD.Ui2FbBTzdBIEg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04102019/9411.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "24": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.9420"
+                                },
+                                {
+                                    "player_id": "9420"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Scooter Gennett",
+                                        "first": "Scooter",
+                                        "last": "Gennett",
+                                        "ascii_first": "Scooter",
+                                        "ascii_last": "Gennett"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.9420"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.26"
+                                },
+                                {
+                                    "editorial_team_full_name": "San Francisco Giants"
+                                },
+                                {
+                                    "editorial_team_abbr": "SF"
+                                },
+                                {
+                                    "uniform_number": "14"
+                                },
+                                {
+                                    "display_position": "2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/ScOL08fa3RuiW5dob5DrnA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04122019/9420.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/ScOL08fa3RuiW5dob5DrnA--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04122019/9420.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566509520
+                                }
+                            ]
+                        ]
+                    },
+                    "count": 25
+                }
+            }
+        ],
+        "time": "59.481859207153ms",
+        "copyright": "Data provided by Yahoo! and STATS, LLC",
+        "refresh_rate": "60"
+    }
+}

--- a/yahoo_fantasy_api/tests/sample.players.freeagents.2B.pg.3.json
+++ b/yahoo_fantasy_api/tests/sample.players.freeagents.2B.pg.3.json
@@ -1,0 +1,428 @@
+{
+    "fantasy_content": {
+        "xml:lang": "en-US",
+        "yahoo:uri": "/fantasy/v2/league/388.l.27081/players;start=175;count=25;status=A;position=2B",
+        "league": [
+            {
+                "league_key": "388.l.27081",
+                "league_id": "27081",
+                "name": "Buck you're next!",
+                "url": "https://baseball.fantasysports.yahoo.com/b1/27081",
+                "logo_url": false,
+                "draft_status": "postdraft",
+                "num_teams": 10,
+                "edit_key": "2019-08-26",
+                "weekly_deadline": "1",
+                "league_update_timestamp": "1566716592",
+                "scoring_type": "head",
+                "league_type": "private",
+                "renew": "378_2210",
+                "renewed": "",
+                "iris_group_chat_id": "ZP2QUJTUB5CPXMXWAVSYZRJI3Y",
+                "allow_add_to_dl_extra_pos": 0,
+                "is_pro_league": "0",
+                "is_cash_league": "0",
+                "current_week": 20,
+                "start_week": "1",
+                "start_date": "2019-03-20",
+                "end_week": "24",
+                "end_date": "2019-09-22",
+                "game_code": "mlb",
+                "season": "2019"
+            },
+            {
+                "players": {
+                    "0": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.11599"
+                                },
+                                {
+                                    "player_id": "11599"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Austin Nola",
+                                        "first": "Austin",
+                                        "last": "Nola",
+                                        "ascii_first": "Austin",
+                                        "ascii_last": "Nola"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.11599"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.12"
+                                },
+                                {
+                                    "editorial_team_full_name": "Seattle Mariners"
+                                },
+                                {
+                                    "editorial_team_abbr": "Sea"
+                                },
+                                {
+                                    "uniform_number": "23"
+                                },
+                                {
+                                    "display_position": "1B,2B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/TcM85WhJ.fAOHWf2QKLjIw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMDA7Y3I9MTtjdz0xNTM7ZHg9NzQ7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/dh/ap/default/140828/silhouette@2x.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/TcM85WhJ.fAOHWf2QKLjIw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMDA7Y3I9MTtjdz0xNTM7ZHg9NzQ7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/dh/ap/default/140828/silhouette@2x.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566272280
+                                }
+                            ]
+                        ]
+                    },
+                    "1": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.11605"
+                                },
+                                {
+                                    "player_id": "11605"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Mike Brosseau",
+                                        "first": "Mike",
+                                        "last": "Brosseau",
+                                        "ascii_first": "Mike",
+                                        "ascii_last": "Brosseau"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.11605"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.30"
+                                },
+                                {
+                                    "editorial_team_full_name": "Tampa Bay Rays"
+                                },
+                                {
+                                    "editorial_team_abbr": "TB"
+                                },
+                                {
+                                    "uniform_number": "43"
+                                },
+                                {
+                                    "display_position": "2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/0ibarXTUKy6vVWW8n2fpdg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/08072019/11605.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/0ibarXTUKy6vVWW8n2fpdg--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/08072019/11605.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                {
+                                    "has_recent_player_notes": 1
+                                },
+                                {
+                                    "player_notes_last_timestamp": 1566698100
+                                }
+                            ]
+                        ]
+                    },
+                    "2": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.11611"
+                                },
+                                {
+                                    "player_id": "11611"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Robel Garcia",
+                                        "first": "Robel",
+                                        "last": "Garcia",
+                                        "ascii_first": "Robel",
+                                        "ascii_last": "Garcia"
+                                    }
+                                },
+                                {
+                                    "status": "NA",
+                                    "status_full": "Not Active"
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.11611"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.16"
+                                },
+                                {
+                                    "editorial_team_full_name": "Chicago Cubs"
+                                },
+                                {
+                                    "editorial_team_abbr": "ChC"
+                                },
+                                {
+                                    "uniform_number": "16"
+                                },
+                                {
+                                    "display_position": "1B,2B,3B"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/TcM85WhJ.fAOHWf2QKLjIw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMDA7Y3I9MTtjdz0xNTM7ZHg9NzQ7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/dh/ap/default/140828/silhouette@2x.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/TcM85WhJ.fAOHWf2QKLjIw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMDA7Y3I9MTtjdz0xNTM7ZHg9NzQ7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/dh/ap/default/140828/silhouette@2x.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "1B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "1B"
+                                        },
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "3B"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                [],
+                                [],
+                                []
+                            ]
+                        ]
+                    },
+                    "3": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.11617"
+                                },
+                                {
+                                    "player_id": "11617"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Tim Lopes",
+                                        "first": "Tim",
+                                        "last": "Lopes",
+                                        "ascii_first": "Tim",
+                                        "ascii_last": "Lopes"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.11617"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.12"
+                                },
+                                {
+                                    "editorial_team_full_name": "Seattle Mariners"
+                                },
+                                {
+                                    "editorial_team_abbr": "Sea"
+                                },
+                                {
+                                    "uniform_number": "10"
+                                },
+                                {
+                                    "display_position": "2B,LF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/TcM85WhJ.fAOHWf2QKLjIw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMDA7Y3I9MTtjdz0xNTM7ZHg9NzQ7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/dh/ap/default/140828/silhouette@2x.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/TcM85WhJ.fAOHWf2QKLjIw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMDA7Y3I9MTtjdz0xNTM7ZHg9NzQ7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/dh/ap/default/140828/silhouette@2x.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "LF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                [],
+                                {
+                                    "player_notes_last_timestamp": 1566008760
+                                }
+                            ]
+                        ]
+                    },
+                    "4": {
+                        "player": [
+                            [
+                                {
+                                    "player_key": "388.p.11623"
+                                },
+                                {
+                                    "player_id": "11623"
+                                },
+                                {
+                                    "name": {
+                                        "full": "Josh Rojas",
+                                        "first": "Josh",
+                                        "last": "Rojas",
+                                        "ascii_first": "Josh",
+                                        "ascii_last": "Rojas"
+                                    }
+                                },
+                                {
+                                    "editorial_player_key": "mlb.p.11623"
+                                },
+                                {
+                                    "editorial_team_key": "mlb.t.29"
+                                },
+                                {
+                                    "editorial_team_full_name": "Arizona Diamondbacks"
+                                },
+                                {
+                                    "editorial_team_abbr": "Ari"
+                                },
+                                {
+                                    "uniform_number": "9"
+                                },
+                                {
+                                    "display_position": "2B,SS,RF"
+                                },
+                                {
+                                    "headshot": {
+                                        "url": "https://s.yimg.com/iu/api/res/1.2/TcM85WhJ.fAOHWf2QKLjIw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMDA7Y3I9MTtjdz0xNTM7ZHg9NzQ7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/dh/ap/default/140828/silhouette@2x.png",
+                                        "size": "small"
+                                    },
+                                    "image_url": "https://s.yimg.com/iu/api/res/1.2/TcM85WhJ.fAOHWf2QKLjIw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMDA7Y3I9MTtjdz0xNTM7ZHg9NzQ7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/dh/ap/default/140828/silhouette@2x.png"
+                                },
+                                {
+                                    "is_undroppable": "0"
+                                },
+                                {
+                                    "position_type": "B"
+                                },
+                                {
+                                    "primary_position": "2B"
+                                },
+                                {
+                                    "eligible_positions": [
+                                        {
+                                            "position": "2B"
+                                        },
+                                        {
+                                            "position": "SS"
+                                        },
+                                        {
+                                            "position": "RF"
+                                        },
+                                        {
+                                            "position": "Util"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "has_player_notes": 1
+                                },
+                                {
+                                    "has_recent_player_notes": 1
+                                },
+                                {
+                                    "player_notes_last_timestamp": 1566702180
+                                }
+                            ]
+                        ]
+                    },
+                    "count": 5
+                }
+            }
+        ],
+        "time": "42.940855026245ms",
+        "copyright": "Data provided by Yahoo! and STATS, LLC",
+        "refresh_rate": "60"
+    }
+}

--- a/yahoo_fantasy_api/tests/test_league.py
+++ b/yahoo_fantasy_api/tests/test_league.py
@@ -70,3 +70,20 @@ def test_team_list(mock_league):
     assert(len(tms) == 10)
     assert(tms[8]['name'] == 'Bobble Addicts')
     assert(tms[8]['team_key'] == '370.l.56877.t.9')
+
+
+def test_free_agents(mock_league):
+    fa = mock_league.free_agents('2B')
+    print(fa)
+    assert(len(fa) == 31)
+    assert(fa[8]['name'] == 'Dee Gordon')
+    assert(fa[8]['position_type'] == 'B')
+    assert(fa[8]['player_id'] == 8863)
+    assert(len(fa[8]['eligible_positions']) == 4)
+    assert(fa[8]['eligible_positions'] == ['2B', 'SS', 'CF', 'Util'])
+    assert(fa[12]['name'] == 'Kolten Wong')
+    assert(fa[12]['position_type'] == 'B')
+    assert(fa[12]['status'] == 'DTD')
+    assert(fa[12]['player_id'] == 9103)
+    assert(len(fa[12]['eligible_positions']) == 2)
+    assert(fa[12]['eligible_positions'] == ['2B', 'Util'])

--- a/yahoo_fantasy_api/yhandler.py
+++ b/yahoo_fantasy_api/yhandler.py
@@ -86,3 +86,31 @@ class YHandler:
         if week is not None:
             week_uri = ";week={}".format(week)
         return self.get("league/{}/scoreboard{}".format(league_id, week_uri))
+
+    def get_players_raw(self, league_id, start, status, position=None):
+        """Return the raw JSON when requesting players in the league
+
+        The result is limited to 25 players.  the first 1000 players.
+
+        :param league_id: League ID to get the players for
+        :type league_id: str
+        :param start: The output is paged at 25 players each time.  Use this
+        parameter for subsequent calls to get the players at the next page.
+        For example, you specify 0 for the first call, 25 for the second call,
+        etc.
+        :type start: int
+        :param status: A filter to limit the player status.  Available values
+        are: 'A' - all available; 'FA' - free agents; 'W' - waivers, 'T' -
+        taken players, 'K' - keepers
+        :type status: str
+        :param position: A filter to return players only for a specific
+        position.  If None is passed, then no position filtering occurs.
+        :type position: str
+        :return: JSON document of the request.
+        """
+        if position is None:
+            pos_parm = ""
+        else:
+            pos_parm = ";position={}".format(position)
+        return self.get("league/{}/players;start={};count=25;status={}{}".
+                        format(league_id, start, status, pos_parm))


### PR DESCRIPTION
This adds the ability to get free agent information from your Yahoo!
league.  It is added to the league class.  You specify the position (as
a short code like '2B', 'SS') or position type (e.g. 'B' for all batters
or 'P' for all pitchers).

A list of all free agents for the position is returned.  For each player
we return:
  - name
  - Yahoo! player ID
  - list of eligible positions
  - position type ('B' for batter or 'P' for pitchers)