### PR TITLE
Fix week_date_range when used during playoffs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 
 setup(name='yahoo_fantasy_api',
-      version='1.1.0',
+      version='1.1.1',
       description='Python bindings to access the Yahoo! Fantasy APIs',
       long_description=readme(),
       url='http://github.com/spilchen/yahoo_fantasy_api',

--- a/yahoo_fantasy_api/tests/test_league.py
+++ b/yahoo_fantasy_api/tests/test_league.py
@@ -2,6 +2,7 @@
 
 import yahoo_fantasy_api as yfa
 import datetime
+import pytest
 
 
 def test_standings(mock_league):
@@ -62,6 +63,20 @@ def test_week_date_range(mock_league):
     assert(sdt == datetime.date(2019, 6, 17))
     print(edt)
     assert(edt == datetime.date(2019, 6, 23))
+
+
+def test_week_date_range_past_current(mock_league):
+    assert(mock_league.current_week() == 12)
+    (sdt, edt) = mock_league.week_date_range(13)
+    print(sdt)
+    assert(sdt == datetime.date(2019, 6, 24))
+    print(edt)
+    assert(edt == datetime.date(2019, 6, 30))
+
+
+def test_week_date_range_of_last(mock_league):
+    with pytest.raises(RuntimeError):
+        (sdt, edt) = mock_league.week_date_range(23)
 
 
 def test_team_list(mock_league):


### PR DESCRIPTION
Prior to this, if you tried to use week_date_range for a future week in
the playoffs you would get an error.  This is because Yahoo! API only
provide the week date range if the matchups for the week are known.  In
the playoffs this isn't possible.  This commit will now restrict any
calls to week_date_range to be at most one week past the current week.