### PR TITLE
Add Average Season stats in req_type

### DIFF
--- a/yahoo_fantasy_api/league.py
+++ b/yahoo_fantasy_api/league.py
@@ -627,9 +627,10 @@ class League:
         :param player_ids: Yahoo! player IDs of the players to get stats for
         :type player_ids: list(int)
         :param req_type: Defines the date range for the stats.  Valid values
-            are: 'season', 'lastweek', 'lastmonth', 'date'.  'season' returns
-            stats for a given season, specified by the season paramter.  'date'
-            returns stats for a single date, specified by the date parameter.
+            are: 'season', 'average_season', 'lastweek', 'lastmonth', 'date'.
+            'season' returns stats for a given season, specified by the season
+            paramter.  'date' returns stats for a single date, specified by
+            the date parameter.
             The 'last*' types return stats for a given time frame relative to
             the current.
         :type req_type: str

--- a/yahoo_fantasy_api/yhandler.py
+++ b/yahoo_fantasy_api/yhandler.py
@@ -339,7 +339,7 @@ class YHandler:
                 return "type=season;season={}".format(season)
         elif req_type == 'average_season':
             if season is None:
-                return "type=season"
+                return "type=average_season"
             else:
                 return "type=average_season;season={}".format(season)
         elif req_type == 'date':

--- a/yahoo_fantasy_api/yhandler.py
+++ b/yahoo_fantasy_api/yhandler.py
@@ -202,7 +202,7 @@ class YHandler:
         return self.get(
             "league/{}/players;player_keys={}/percent_owned".
             format(league_id, joined_ids))
-    
+
     def get_player_ownership_raw(self, league_id, player_ids):
         """Return the raw JSON when requesting the ownership of players
 
@@ -337,6 +337,11 @@ class YHandler:
                 return "type=season"
             else:
                 return "type=season;season={}".format(season)
+        elif req_type == 'average_season':
+            if season is None:
+                return "type=season"
+            else:
+                return "type=average_season;season={}".format(season)
         elif req_type == 'date':
             if date is None:
                 date = datetime.date.today()


### PR DESCRIPTION
This PR is to add average season stats to the req_type to return a player or players' average stat.

## Test
Joel Embiid's average season with just `type=average_season`
<img width="1036" alt="Screen Shot 2021-10-30 at 11 11 10 PM" src="https://user-images.githubusercontent.com/39326969/139537347-c9d62b02-ca04-40a0-8f1c-6aeeecb20c8a.png">

Joel Embiid's average season with `type=average_season` and `season=2021`
<img width="1030" alt="Screen Shot 2021-10-30 at 11 32 13 PM" src="https://user-images.githubusercontent.com/39326969/139537394-a0b26ce7-f787-4f90-a7fb-9e1f38f6481f.png">


