### PR TITLE
Master | Noah/Adding support for "week" in queries for NFL leagues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 
 setup(name='yahoo_fantasy_api',
-      version='2.5.1',
+      version='2.6.0',
       description='Python bindings to access the Yahoo! Fantasy APIs',
       long_description=readme(),
       url='http://github.com/spilchen/yahoo_fantasy_api',

--- a/yahoo_fantasy_api/league.py
+++ b/yahoo_fantasy_api/league.py
@@ -627,10 +627,11 @@ class League:
         :param player_ids: Yahoo! player IDs of the players to get stats for
         :type player_ids: list(int)
         :param req_type: Defines the date range for the stats.  Valid values
-            are: 'season', 'average_season', 'lastweek', 'lastmonth', 'date'.
+            are: 'season', 'average_season', 'lastweek', 'lastmonth', 'date', 'week'.
             'season' returns stats for a given season, specified by the season
-            paramter.  'date' returns stats for a single date, specified by
-            the date parameter.
+            parameter.  'date' returns stats for a single date, specified by
+            the date parameter. 'week' returns stats for a single week, specified by
+            the week parameter.
             The 'last*' types return stats for a given time frame relative to
             the current.
         :type req_type: str

--- a/yahoo_fantasy_api/league.py
+++ b/yahoo_fantasy_api/league.py
@@ -621,7 +621,7 @@ class League:
             self.positions_cache = pmap
         return self.positions_cache
 
-    def player_stats(self, player_ids, req_type, date=None, season=None):
+    def player_stats(self, player_ids, req_type, date=None, week=None, season=None):
         """Return stats for a list of players
 
         :param player_ids: Yahoo! player IDs of the players to get stats for
@@ -638,6 +638,10 @@ class League:
             what date to request the stats for.  If left as None, and range
             is for a date this returns stats for the current date.
         :type date: datetime.date
+        :param week: NFL ONLY: When requesting stats for a week, this identifies the
+            week.  If None and requesting stats for a season, this will
+            return stats for the current season.
+        :type week: int
         :param season: When requesting stats for a season, this identifies the
             season.  If None and requesting stats for a season, this will
             return stats for the current season.
@@ -686,7 +690,7 @@ class League:
             next_player_ids = player_ids[0:25]
             player_ids = player_ids[25:]
             stats += self._fetch_plyr_stats(game_code, next_player_ids,
-                                            req_type, date, season)
+                                            req_type, date, week, season)
         return stats
 
     def draft_results(self):
@@ -763,7 +767,7 @@ class League:
             transactions.append({**transaction_details, **players})
         return transactions
 
-    def _fetch_plyr_stats(self, game_code, player_ids, req_type, date, season):
+    def _fetch_plyr_stats(self, game_code, player_ids, req_type, date, week, season):
         '''
         Fetch player stats for at most 25 player IDs.
 
@@ -771,13 +775,14 @@ class League:
         :param player_ids: List of up to 25 player IDs
         :param req_type: Request type
         :param date: Date if request type is 'date'
+        :param week: NFL ONLY: Week number if request type is 'week'
         :param season: Season if request type is 'season'
         :return: The stats requested
         :rtype: list(dict)
         '''
         assert(len(player_ids) > 0 and len(player_ids) <= 25)
         json = self.yhandler.get_player_stats_raw(game_code, player_ids,
-                                                  req_type, date, season)
+                                                  req_type, date, week, season)
         t = objectpath.Tree(json)
         stats = []
         row = None

--- a/yahoo_fantasy_api/tests/mock_yhandler.py
+++ b/yahoo_fantasy_api/tests/mock_yhandler.py
@@ -124,7 +124,7 @@ class YHandler:
             return json.load(f)
 
     def get_player_stats_raw(self, game_code, player_ids, req_type, day,
-                             season):
+                             week, season):
         if game_code == 'nhl':
             id = "396.l.21484"
         else:

--- a/yahoo_fantasy_api/yhandler.py
+++ b/yahoo_fantasy_api/yhandler.py
@@ -341,10 +341,11 @@ class YHandler:
             else:
                 return "type=season;season={}".format(season)
         elif req_type == 'week':
+            print(req_type)
             if week is None:
                 return "type=week"
             else:
-                return "sort_type=week;sort_week={}".format(week)
+                return "type=week;week={}".format(week)
         elif req_type == 'average_season':
             if season is None:
                 return "type=average_season"

--- a/yahoo_fantasy_api/yhandler.py
+++ b/yahoo_fantasy_api/yhandler.py
@@ -288,7 +288,7 @@ class YHandler:
         return self.put("transaction/" + str(transaction_key), xml)
 
     def get_player_stats_raw(self, game_code, player_ids, req_type, date,
-                             season):
+                             week, season):
         """
         GET stats for a list of player IDs
 
@@ -301,13 +301,16 @@ class YHandler:
         :param date: When req_type == 'date', this is the date we want the
             stats for.  If None, we'll get the stats for the current date.
         :type date: datetime.date
+        :param week: NFL ONLY: When req_type == 'week', this is the week we want
+            the stats for.  If None, we'll get the stats for the current week
+        :type season: int
         :param season: When req_type == 'season', this is the season we want
             the stats for.  If None, we'll get the stats for the current season
         :type season: int
         :return: Response from the GET call
         """
         uri = self._build_player_stats_uri(game_code, player_ids, req_type,
-                                           date, season)
+                                           date, week, season)
         return self.get(uri)
 
     def get_draftresults_raw(self, league_id):
@@ -321,22 +324,27 @@ class YHandler:
         return self.get("league/{}/draftresults".format(league_id))
 
     def _build_player_stats_uri(self, game_code, player_ids, req_type, date,
-                                season):
+                                week, season):
         uri = 'players;player_keys='
         if type(player_ids) is list:
             for i, p in enumerate(player_ids):
                 if i != 0:
                     uri += ","
                 uri += "{}.p.{}".format(game_code, p)
-        uri += "/stats;{}".format(self._get_stats_type(req_type, date, season))
+        uri += "/stats;{}".format(self._get_stats_type(req_type, date, week, season))
         return uri
 
-    def _get_stats_type(self, req_type, date, season):
+    def _get_stats_type(self, req_type, date, week, season):
         if req_type == 'season':
             if season is None:
                 return "type=season"
             else:
                 return "type=season;season={}".format(season)
+        elif req_type == 'week':
+            if week is None:
+                return "type=week"
+            else:
+                return "sort_type=week;sort_week={}".format(week)
         elif req_type == 'average_season':
             if season is None:
                 return "type=average_season"

--- a/yahoo_fantasy_api/yhandler.py
+++ b/yahoo_fantasy_api/yhandler.py
@@ -341,7 +341,6 @@ class YHandler:
             else:
                 return "type=season;season={}".format(season)
         elif req_type == 'week':
-            print(req_type)
             if week is None:
                 return "type=week"
             else:


### PR DESCRIPTION
When requesting data for NFL leagues, we need to be able to request data at the "week" level. I added support for this by adding "week" parameters to the methods in the League class and the YHandler class.

To test:

```python
# Authenticate to Yahoo with oauth 
oauth = OAuth2(None, None, from_file=oauth_file)

game = yfa.Game(oauth, 'nfl')
league_ids = game.league_ids()
league_id = league_ids[-1]

# Create an instance of the League class
league = yfa.League(oauth, league_id)

league.player_stats([33495], 'week', week=1)[0]
```