### PR TITLE
Ignore KeyError when querying draft results during live draft

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 
 setup(name='yahoo_fantasy_api',
-      version='2.7.0',
+      version='2.7.1',
       description='Python bindings to access the Yahoo! Fantasy APIs',
       long_description=readme(),
       url='http://github.com/spilchen/yahoo_fantasy_api',

--- a/yahoo_fantasy_api/league.py
+++ b/yahoo_fantasy_api/league.py
@@ -748,13 +748,16 @@ class League:
         dres = []
         pat = re.compile(r'.*\.p\.([0-9]+)$')
         for p in t.execute('$..draft_results..draft_result'):
-            pk = p['player_key']
-            m = pat.search(pk)
-            if m:
-                pid = int(m.group(1))
-                p['player_id'] = pid
-                del p['player_key']
-            dres.append(p)
+            try:
+                pk = p['player_key']
+                m = pat.search(pk)
+                if m:
+                    pid = int(m.group(1))
+                    p['player_id'] = pid
+                    del p['player_key']
+                dres.append(p)
+            except KeyError:
+                pass
         return(dres)
 
     def transactions(self, tran_types, count):


### PR DESCRIPTION
Fixes issue reported in https://github.com/spilchen/yahoo_fantasy_api/issues/27