### PR TITLE
Remove Travis build status badge (returning HTTP 404)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,6 @@ Python bindings to the Yahoo! Fantasy API
 
 Build status
 ------------
-
-.. image:: https://travis-ci.com/spilchen/yahoo_fantasy_api.svg?branch=master
-    :target: https://travis-ci.com/spilchen/yahoo_fantasy_api
     
 .. image:: https://readthedocs.org/projects/yahoo-fantasy-api/badge/?version=latest
    :target: https://yahoo-fantasy-api.readthedocs.io/en/latest/?badge=latest


### PR DESCRIPTION
In PR #37:

.travis.yml was deleted, and replaced with [.github/workflows/ut.yaml](https://github.com/spilchen/yahoo_fantasy_api/blob/master/.github/workflows/ut.yaml)

Screenshot of README at time of this PR:

<img width="608" alt="Screenshot 2024-09-08 at 3 44 34 PM" src="https://github.com/user-attachments/assets/d31927a0-5e38-4ad6-8661-7d9de70cc010">

