### PR TITLE
Add support for waivers with faab

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 
 setup(name='yahoo_fantasy_api',
-      version='2.9.1',
+      version='2.10.0',
       description='Python bindings to access the Yahoo! Fantasy APIs',
       long_description=readme(),
       url='http://github.com/spilchen/yahoo_fantasy_api',

--- a/yahoo_fantasy_api/team.py
+++ b/yahoo_fantasy_api/team.py
@@ -150,7 +150,7 @@ class Team:
         self.yhandler.post_transactions(self.league_id, xml)
 
     def claim_player(self, player_id, faab=None):
-        """Claim a single player from waivers by their player ID
+        """Submit a waiver claim for a single player by their player ID
 
         :param player_id: Yahoo! player ID of the player to add
         :type player_id: int
@@ -188,7 +188,7 @@ class Team:
         self.yhandler.post_transactions(self.league_id, xml)
 
     def claim_and_drop_players(self, add_player_id, drop_player_id, faab=None):
-        """Claim one player from waivers and drop another in the same transaction
+        """Submit a waiver claim for one player and drop another in the same transaction
 
         :param add_player_id: Yahoo! player ID of the player to add
         :type add_player_id: int

--- a/yahoo_fantasy_api/team.py
+++ b/yahoo_fantasy_api/team.py
@@ -149,6 +149,19 @@ class Team:
         xml = self._construct_transaction_xml("add", player_id)
         self.yhandler.post_transactions(self.league_id, xml)
 
+    def claim_player(self, player_id, faab=None):
+        """Claim a single player from waivers by their player ID
+
+        :param player_id: Yahoo! player ID of the player to add
+        :type player_id: int
+        :param faab: Number of faab dollars to bid on the claim
+        :type faab: int
+
+        >>> tm.add_player(6767, faab=7)
+        """
+        xml = self._construct_transaction_xml("add", player_id, faab=faab)
+        self.yhandler.post_transactions(self.league_id, xml)
+
     def drop_player(self, player_id):
         """Drop a single player by their player ID
 
@@ -172,6 +185,23 @@ class Team:
         """
         xml = self._construct_transaction_xml("add/drop", add_player_id,
                                               drop_player_id)
+        self.yhandler.post_transactions(self.league_id, xml)
+
+    def claim_and_drop_players(self, add_player_id, drop_player_id, faab=None):
+        """Claim one player from waivers and drop another in the same transaction
+
+        :param add_player_id: Yahoo! player ID of the player to add
+        :type add_player_id: int
+        :param drop_player_id: Yahoo! player ID of the player to drop
+        :type drop_player_id: int
+        :param faab: Number of faab dollars to bid on the claim
+        :type faab: int
+
+        >>> tm.claim_and_drop_players(6770, 6767, faab=22)
+        """
+        xml = self._construct_transaction_xml(
+            "add/drop", add_player_id, drop_player_id, faab=faab
+        )
         self.yhandler.post_transactions(self.league_id, xml)
 
     def proposed_trades(self):
@@ -408,13 +438,18 @@ class Team:
 
         return doc.toprettyxml()
 
-    def _construct_transaction_xml(self, action, *player_ids):
+    def _construct_transaction_xml(self, action, *player_ids, faab=None):
         doc = Document()
         transaction = doc.appendChild(doc.createElement('fantasy_content')) \
             .appendChild(doc.createElement('transaction'))
 
         transaction.appendChild(doc.createElement('type')) \
             .appendChild(doc.createTextNode(action))
+
+        if faab is not None:
+            transaction.appendChild(doc.createElement("faab_bid")) \
+                .appendChild(doc.createTextNode(str(faab)))
+
         if action == 'add/drop':
             players = transaction.appendChild(doc.createElement('players'))
             self._construct_transaction_player_xml(doc, players, player_ids[0],

--- a/yahoo_fantasy_api/tests/add_drop_no_faab.xml
+++ b/yahoo_fantasy_api/tests/add_drop_no_faab.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<fantasy_content>
+  <transaction>
+    <type>add/drop</type>
+    <players>
+      <player>
+        <player_key>268.p.123</player_key>
+        <transaction_data>
+          <type>add</type>
+          <destination_team_key>268.l.46645</destination_team_key>
+        </transaction_data>
+      </player>
+      <player>
+        <player_key>268.p.456</player_key>
+        <transaction_data>
+          <type>drop</type>
+          <source_team_key>268.l.46645</source_team_key>
+        </transaction_data>
+      </player>
+    </players>
+  </transaction>
+</fantasy_content>

--- a/yahoo_fantasy_api/tests/add_drop_with_faab.xml
+++ b/yahoo_fantasy_api/tests/add_drop_with_faab.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<fantasy_content>
+  <transaction>
+    <type>add/drop</type>
+    <faab_bid>99</faab_bid>
+    <players>
+      <player>
+        <player_key>268.p.123</player_key>
+        <transaction_data>
+          <type>add</type>
+          <destination_team_key>268.l.46645</destination_team_key>
+        </transaction_data>
+      </player>
+      <player>
+        <player_key>268.p.456</player_key>
+        <transaction_data>
+          <type>drop</type>
+          <source_team_key>268.l.46645</source_team_key>
+        </transaction_data>
+      </player>
+    </players>
+  </transaction>
+</fantasy_content>

--- a/yahoo_fantasy_api/tests/test_team.py
+++ b/yahoo_fantasy_api/tests/test_team.py
@@ -5,6 +5,8 @@ import datetime
 import pytest
 
 
+DIR_PATH = os.path.dirname(os.path.realpath(__file__))
+
 def test_matchup(mock_team):
     opponent = mock_team.matchup(3)
     assert(opponent == '388.l.27081.t.5')
@@ -58,8 +60,7 @@ def test_proposed_trades(mock_team):
 
 
 def test__construct_trade_xml(mock_team):
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    with open(f'{dir_path}/accept_trade.xml', 'r') as file:
+    with open(f'{DIR_PATH}/accept_trade.xml', 'r') as file:
         expected_xml = file.read().replace('  ', '\t')
 
     transaction_key = '396.l.49770.pt.1'
@@ -69,8 +70,7 @@ def test__construct_trade_xml(mock_team):
 
 
 def test__construct_trade_proposal_xml(mock_team):
-    dir_path = os.path.dirname(os.path.realpath(__file__))
-    with open(f'{dir_path}/trade_proposal.xml', 'r') as file:
+    with open(f'{DIR_PATH}/trade_proposal.xml', 'r') as file:
         expected_xml = file.read().replace('  ', '\t')
 
     tradee_team_key = '248.l.55438.t.4'
@@ -80,6 +80,37 @@ def test__construct_trade_proposal_xml(mock_team):
 
     actual_xml = mock_team._construct_trade_proposal_xml(
         tradee_team_key, your_player_keys, their_player_keys, trade_note)
+
+    assert actual_xml == expected_xml
+
+
+def test__construct_transaction_xml(mock_team):
+    with open(f'{DIR_PATH}/add_drop_with_faab.xml', 'r') as file:
+        expected_xml = file.read().replace('  ', '\t')
+
+    action = "add/drop"
+    add_player_id=123
+    drop_player_id=456
+    faab = 99
+
+    actual_xml = mock_team._construct_transaction_xml(
+        action, add_player_id, drop_player_id, faab=faab
+    )
+
+    assert actual_xml == expected_xml
+
+
+def test__construct_transaction_xml_with_faab(mock_team):
+    with open(f'{DIR_PATH}/add_drop_no_faab.xml', 'r') as file:
+        expected_xml = file.read().replace('  ', '\t')
+
+    action = "add/drop"
+    add_player_id=123
+    drop_player_id=456
+
+    actual_xml = mock_team._construct_transaction_xml(
+        action, add_player_id, drop_player_id
+    )
 
     assert actual_xml == expected_xml
 


### PR DESCRIPTION
Adds [Team](https://github.com/spilchen/yahoo_fantasy_api/blob/6b26e6b/yahoo_fantasy_api/team.py#L11) methods for bidding faab on waiver claims. 

## Testing

Confirmed in my home league that with these new methods I could successfully make waiver claims, whereas using the existing `add_player` and `add_and_drop_players` methods would encounter:
```
...FAB balance must be a whole number betweed $0 and $999999999.</description>\n <detail/>\n</error>'
```
