### PR TITLE
Add editorial_team_abbr to roster() and free_agents() responses

### DIFF
--- a/yahoo_fantasy_api/league.py
+++ b/yahoo_fantasy_api/league.py
@@ -313,7 +313,8 @@ class League:
         {'player_id': 8370,
          'name': 'Dexter Fowler',
          'position_type': 'B',
-         'eligible_positions': ['CF', 'RF', 'Util']}
+         'eligible_positions': ['CF', 'RF', 'Util'],
+         'editorial_team_abbr': 'StL'}
         """
         if position not in self.free_agent_cache:
             self.free_agent_cache[position] = self._fetch_players(
@@ -424,7 +425,8 @@ class League:
         for i, pct_own in zip(range(0, t.execute('$..players.count[0]') * 2, 2),
                               pct_owns):
             path = '$..players..player[{}].'.format(i) + \
-                "(name,player_id,position_type,status,eligible_positions)"
+                "(name,player_id,position_type,status," \
+                "eligible_positions,editorial_team_abbr)"
             obj = list(t.execute(path))
             plyr = {}
             # Convert obj from a list of dicts to a single one-dimensional dict
@@ -439,6 +441,8 @@ class League:
             plyr['percent_owned'] = pct_own
             if "status" not in plyr:
                 plyr["status"] = ""
+            if "editorial_team_abbr" not in plyr:
+                plyr["editorial_team_abbr"] = ""
 
             # Ignore players that are not active
             if plyr["status"] != "NA":

--- a/yahoo_fantasy_api/team.py
+++ b/yahoo_fantasy_api/team.py
@@ -73,7 +73,7 @@ class Team:
         :type day: :class: datetime.date
         :return: Array of players.  Each entry is a dict with the following
            fields: player_id, name, position_type, eligible_positions,
-           selected_position
+           selected_position, editorial_team_abbr
 
         >>> tm.roster(3)
         [{'player_id': 8578, 'name': 'John Doe', 'position_type': 'B',
@@ -146,6 +146,8 @@ class Team:
                     plyr['player_id'] = int(item['player_id'])
                 elif 'name' in item and 'full' in item['name']:
                     plyr['name'] = item['name']['full']
+                elif 'editorial_team_abbr' in item:
+                    plyr['editorial_team_abbr'] = item['editorial_team_abbr']
                 elif 'position_type' in item:
                     # Skip the linked_player position_type.
                     if 'player_id' not in plyr:
@@ -158,6 +160,8 @@ class Team:
 
             # Get status.
             plyr['status'] = _get_player_status(player_data)
+            if 'editorial_team_abbr' not in plyr:
+                plyr['editorial_team_abbr'] = ""
 
             # Extract selected_position.
             if 'selected_position' in selected_position_data:

--- a/yahoo_fantasy_api/tests/test_league.py
+++ b/yahoo_fantasy_api/tests/test_league.py
@@ -108,6 +108,13 @@ def test_free_agents(mock_mlb_league):
     assert(fa[21]['eligible_positions'] == ['C', 'LW'])
 
 
+def test_free_agents_editorial_team_abbr(mock_mlb_league):
+    fa = mock_mlb_league.free_agents('C')
+    assert 'editorial_team_abbr' in fa[0]
+    assert fa[0]['name'] == 'Joe Thornton'
+    assert fa[0]['editorial_team_abbr'] == 'SJ'
+
+
 def test_pct_own_in_free_agents(mock_mlb_league):
     fa = mock_mlb_league.free_agents('C')
     print(fa)

--- a/yahoo_fantasy_api/tests/test_team.py
+++ b/yahoo_fantasy_api/tests/test_team.py
@@ -31,6 +31,14 @@ def test_roster(mock_team):
     assert(r[5]['selected_position'] == 'LF')
 
 
+def test_roster_editorial_team_abbr(mock_team):
+    r = mock_team.roster(3)
+    assert r[0]['name'] == 'Danny Jansen'
+    assert r[0]['editorial_team_abbr'] == 'Tor'
+    assert r[5]['name'] == 'Yordan Alvarez'
+    assert r[5]['editorial_team_abbr'] == 'Hou'
+
+
 def test_roster_status(mock_team):
     r = mock_team.roster(3)
     print(r)


### PR DESCRIPTION
The raw Yahoo API responses already include editorial_team_abbr for each player, but it was being dropped during parsing. This adds it to the dicts returned by Team.roster(), League.free_agents(), League.waivers(), and League.taken_players(), defaulting to "" when absent.