### PR TITLE
Add position filter to waivers() for FAB league support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 
 setup(name='yahoo_fantasy_api',
-      version='2.12.2',
+      version='2.12.3',
       description='Python bindings to access the Yahoo! Fantasy APIs',
       long_description=readme(),
       url='http://github.com/spilchen/yahoo_fantasy_api',

--- a/yahoo_fantasy_api/league.py
+++ b/yahoo_fantasy_api/league.py
@@ -28,7 +28,7 @@ class League:
         self.end_week_cache = None
         self.week_date_range_cache = {}
         self.free_agent_cache = {}
-        self.waivers_cache = None
+        self.waivers_cache = {}
         self.taken_players_cache = None
         self.stat_categories_cache = None
         self.settings_cache = None
@@ -321,9 +321,14 @@ class League:
                 'FA', position=position)
         return self.free_agent_cache[position]
 
-    def waivers(self):
+    def waivers(self, position=None):
         """Return the players currently on waivers.
 
+        :param position: If not None, only return players that are eligible
+             for the given position.  Use the short code of the position
+             (e.g. 2B, C, etc.).  You can also specify the position type
+             (e.g. 'B' for all batters and 'P' for all pitchers).
+        :type position: str
         :return: Players on waiver.
         :rtype: List(dict)
 
@@ -347,9 +352,10 @@ class League:
           'eligible_positions': ['D', 'IR'],
           'percent_owned': 87}]
         """
-        if not self.waivers_cache:
-            self.waivers_cache = self._fetch_players('W')
-        return self.waivers_cache
+        if position not in self.waivers_cache:
+            self.waivers_cache[position] = self._fetch_players(
+                'W', position=position)
+        return self.waivers_cache[position]
 
     def taken_players(self):
         """Return the players taken by teams.

--- a/yahoo_fantasy_api/tests/mock_yhandler.py
+++ b/yahoo_fantasy_api/tests/mock_yhandler.py
@@ -119,8 +119,8 @@ class YHandler:
             return json.load(f)
 
     def get_players_raw(self, league_id, start, status, position=None):
-        assert(position == "C"), "Position must be 2B for mock"
-        assert(status == "FA"), "FreeAgents only for mock"
+        assert(position == "C"), "Position must be C for mock"
+        assert status in ("FA", "W"), "Status must be FA or W for mock"
         if start == 0:
             pg = "1"
         elif start == 25:

--- a/yahoo_fantasy_api/tests/test_league.py
+++ b/yahoo_fantasy_api/tests/test_league.py
@@ -115,6 +115,14 @@ def test_free_agents_editorial_team_abbr(mock_mlb_league):
     assert fa[0]['editorial_team_abbr'] == 'SJ'
 
 
+def test_waivers_with_position(mock_mlb_league):
+    wa = mock_mlb_league.waivers('C')
+    assert len(wa) == 42
+    assert wa[0]['name'] == 'Joe Thornton'
+    assert wa[0]['position_type'] == 'P'
+    assert wa[0]['player_id'] == 1600
+
+
 def test_pct_own_in_free_agents(mock_mlb_league):
     fa = mock_mlb_league.free_agents('C')
     print(fa)


### PR DESCRIPTION
In FAB leagues all unowned players are on waivers, so free_agents() returns nothing. The waivers() method worked but lacked a position parameter, forcing callers to fetch all waiver players and filter client-side. This adds an optional position parameter mirroring free_agents(), and switches the cache to a position-keyed dict.