### PR TITLE
Add sort/count support to the players collection

### DIFF
--- a/yahoo_fantasy_api/league.py
+++ b/yahoo_fantasy_api/league.py
@@ -294,7 +294,8 @@ class League:
                                "{}, but current week is {}.".format(
                                    week, self.current_week()))
 
-    def free_agents(self, position):
+    def free_agents(self, position, sort=None, sort_type=None,
+                    sort_season=None):
         """Return the free agents for the given position
 
         :param position: All free agents must be able to play this position.
@@ -302,6 +303,17 @@ class League:
              also specify the position type (e.g. 'B' for all batters and 'P'
              for all pitchers).
         :type position: str
+        :param sort: How to order the returned players.  Accepts a Yahoo named
+             sort ('AR', 'OR', 'NAME', 'PTS', ...) or a numeric stat ID.  If
+             None, Yahoo's default ordering is used.
+        :type sort: str
+        :param sort_type: The window the ``sort`` applies over: 'season',
+             'lastweek', 'lastmonth', or 'biweekly'.  Only meaningful alongside
+             a stat-based ``sort``.
+        :type sort_type: str
+        :param sort_season: The season to sort by.  Required by Yahoo when
+             ``sort_type`` is 'season'.
+        :type sort_season: str
         :return: Free agents found. Particulars about each free agent will be
              returned.
         :rtype: List(Dict)
@@ -316,12 +328,15 @@ class League:
          'eligible_positions': ['CF', 'RF', 'Util'],
          'editorial_team_abbr': 'StL'}
         """
-        if position not in self.free_agent_cache:
-            self.free_agent_cache[position] = self._fetch_players(
-                'FA', position=position)
-        return self.free_agent_cache[position]
+        key = (position, sort, sort_type, sort_season)
+        if key not in self.free_agent_cache:
+            self.free_agent_cache[key] = self._fetch_players(
+                'FA', position=position, sort=sort, sort_type=sort_type,
+                sort_season=sort_season)
+        return self.free_agent_cache[key]
 
-    def waivers(self, position=None):
+    def waivers(self, position=None, sort=None, sort_type=None,
+                sort_season=None):
         """Return the players currently on waivers.
 
         :param position: If not None, only return players that are eligible
@@ -329,6 +344,17 @@ class League:
              (e.g. 2B, C, etc.).  You can also specify the position type
              (e.g. 'B' for all batters and 'P' for all pitchers).
         :type position: str
+        :param sort: How to order the returned players.  Accepts a Yahoo named
+             sort ('AR', 'OR', 'NAME', 'PTS', ...) or a numeric stat ID.  If
+             None, Yahoo's default ordering is used.
+        :type sort: str
+        :param sort_type: The window the ``sort`` applies over: 'season',
+             'lastweek', 'lastmonth', or 'biweekly'.  Only meaningful alongside
+             a stat-based ``sort``.
+        :type sort_type: str
+        :param sort_season: The season to sort by.  Required by Yahoo when
+             ``sort_type`` is 'season'.
+        :type sort_season: str
         :return: Players on waiver.
         :rtype: List(dict)
 
@@ -352,10 +378,12 @@ class League:
           'eligible_positions': ['D', 'IR'],
           'percent_owned': 87}]
         """
-        if position not in self.waivers_cache:
-            self.waivers_cache[position] = self._fetch_players(
-                'W', position=position)
-        return self.waivers_cache[position]
+        key = (position, sort, sort_type, sort_season)
+        if key not in self.waivers_cache:
+            self.waivers_cache[key] = self._fetch_players(
+                'W', position=position, sort=sort, sort_type=sort_type,
+                sort_season=sort_season)
+        return self.waivers_cache[key]
 
     def taken_players(self):
         """Return the players taken by teams.
@@ -378,7 +406,8 @@ class League:
             self.taken_players_cache = self._fetch_players('T')
         return self.taken_players_cache
 
-    def _fetch_players(self, status, position=None):
+    def _fetch_players(self, status, position=None, sort=None,
+                       sort_type=None, sort_season=None):
         """Fetch players from Yahoo!
 
         :param status: Indicates what type of players to get.  Available
@@ -388,6 +417,15 @@ class League:
         :param position: An optional parameter that allows you to filter on a
             position to type of player.  If None, this option is ignored.
         :type postition: str
+        :param sort: Optional ordering for the returned players.  Accepts a
+            Yahoo named sort or a numeric stat ID.  If None, it is ignored.
+        :type sort: str
+        :param sort_type: Optional window for ``sort`` ('season', 'lastweek',
+            'lastmonth', 'biweekly').  If None, it is ignored.
+        :type sort_type: str
+        :param sort_season: Optional season for ``sort_type='season'``.  If
+            None, it is ignored.
+        :type sort_season: str
         :return: Players found.
         :rtype: List(Dict)
         """
@@ -398,8 +436,9 @@ class League:
         plyrs = []
         plyrIndex = 0
         while plyrIndex % PLAYERS_PER_PAGE == 0:
-            j = self.yhandler.get_players_raw(self.league_id, plyrIndex,
-                                              status, position=position)
+            j = self.yhandler.get_players_raw(
+                self.league_id, plyrIndex, status, position=position,
+                sort=sort, sort_type=sort_type, sort_season=sort_season)
             (num_plyrs_on_pg, fa_on_pg) = self._players_from_page(j)
             if len(fa_on_pg) == 0:
                 break

--- a/yahoo_fantasy_api/tests/mock_yhandler.py
+++ b/yahoo_fantasy_api/tests/mock_yhandler.py
@@ -118,7 +118,8 @@ class YHandler:
         with open(fn, "r") as f:
             return json.load(f)
 
-    def get_players_raw(self, league_id, start, status, position=None):
+    def get_players_raw(self, league_id, start, status, position=None,
+                        sort=None, sort_type=None, sort_season=None, count=25):
         assert(position == "C"), "Position must be C for mock"
         assert status in ("FA", "W"), "Status must be FA or W for mock"
         if start == 0:

--- a/yahoo_fantasy_api/tests/test_league.py
+++ b/yahoo_fantasy_api/tests/test_league.py
@@ -115,6 +115,17 @@ def test_free_agents_editorial_team_abbr(mock_mlb_league):
     assert fa[0]['editorial_team_abbr'] == 'SJ'
 
 
+def test_free_agents_sorted(mock_mlb_league):
+    # The sort parameters flow through to the request and cache separately
+    # from an unsorted fetch (the mock ignores sort, so contents match).
+    fa = mock_mlb_league.free_agents('C', sort='60', sort_type='season',
+                                     sort_season='2023')
+    assert len(fa) == 42
+    key = ('C', '60', 'season', '2023')
+    assert key in mock_mlb_league.free_agent_cache
+    assert ('C', None, None, None) not in mock_mlb_league.free_agent_cache
+
+
 def test_waivers_with_position(mock_mlb_league):
     wa = mock_mlb_league.waivers('C')
     assert len(wa) == 42

--- a/yahoo_fantasy_api/tests/test_yhandler.py
+++ b/yahoo_fantasy_api/tests/test_yhandler.py
@@ -24,6 +24,31 @@ def test_roster_raw():
     yh.get.assert_called_with("team/{}/roster".format(team_key))
 
 
+def test_get_players_raw():
+    yh = yhandler.YHandler('dummy-sc')
+    yh.get = MagicMock(return_value=None)
+    league_id = "399.l.710921"
+
+    # Defaults produce the original URL (backward compatible).
+    yh.get_players_raw(league_id, 0, "FA")
+    yh.get.assert_called_with(
+        "league/{}/players;start=0;count=25;status=FA/percent_owned".format(
+            league_id))
+
+    # Position filter.
+    yh.get_players_raw(league_id, 25, "W", position="2B")
+    yh.get.assert_called_with(
+        "league/{}/players;start=25;count=25;status=W;position=2B"
+        "/percent_owned".format(league_id))
+
+    # Stat-based sort with a window and a custom page size.
+    yh.get_players_raw(league_id, 0, "FA", sort="60", sort_type="season",
+                       sort_season="2023", count=10)
+    yh.get.assert_called_with(
+        "league/{}/players;start=0;count=10;status=FA;sort=60"
+        ";sort_type=season;sort_season=2023/percent_owned".format(league_id))
+
+
 def test_game_raw():
     yh = yhandler.YHandler('dummy-sc')
     yh.get = MagicMock(return_value=None)

--- a/yahoo_fantasy_api/yhandler.py
+++ b/yahoo_fantasy_api/yhandler.py
@@ -256,17 +256,19 @@ class YHandler:
             week_uri = ";week={}".format(week)
         return self.get("league/{}/scoreboard{}".format(league_id, week_uri))
 
-    def get_players_raw(self, league_id, start, status, position=None):
+    def get_players_raw(self, league_id, start, status, position=None,
+                        sort=None, sort_type=None, sort_season=None, count=25):
         """Return the raw JSON when requesting players in the league
 
-        The result is limited to 25 players.
+        The result is limited to ``count`` players (25 by default, which is
+        also Yahoo's per-page maximum).
 
         :param league_id: League ID to get the players for
         :type league_id: str
-        :param start: The output is paged at 25 players each time.  Use this
-        parameter for subsequent calls to get the players at the next page.
-        For example, you specify 0 for the first call, 25 for the second call,
-        etc.
+        :param start: The output is paged at ``count`` players each time.  Use
+        this parameter for subsequent calls to get the players at the next
+        page.  For example, you specify 0 for the first call, 25 for the second
+        call, etc.
         :type start: int
         :param status: A filter to limit the player status.  Available values
         are: 'A' - all available; 'FA' - free agents; 'W' - waivers, 'T' -
@@ -275,15 +277,33 @@ class YHandler:
         :param position: A filter to return players only for a specific
         position.  If None is passed, then no position filtering occurs.
         :type position: str
+        :param sort: How to order the returned players.  Accepts a Yahoo named
+        sort ('AR', 'OR', 'NAME', 'PTS', ...) or a numeric stat ID (e.g. '60').
+        If None, Yahoo's default ordering is used.
+        :type sort: str
+        :param sort_type: The window the ``sort`` applies over: 'season',
+        'lastweek', 'lastmonth', or 'biweekly'.  Only meaningful alongside a
+        stat-based ``sort``.  If None, it is omitted.
+        :type sort_type: str
+        :param sort_season: The season to sort by.  Required by Yahoo when
+        ``sort_type`` is 'season'.  If None, it is omitted.
+        :type sort_season: str
+        :param count: The number of players to return (Yahoo caps this at 25
+        per page).  Defaults to 25.
+        :type count: int
         :return: JSON document of the request.
         """
-        if position is None:
-            pos_parm = ""
-        else:
-            pos_parm = ";position={}".format(position)
+        filters = "start={};count={};status={}".format(start, count, status)
+        if position is not None:
+            filters += ";position={}".format(position)
+        if sort is not None:
+            filters += ";sort={}".format(sort)
+        if sort_type is not None:
+            filters += ";sort_type={}".format(sort_type)
+        if sort_season is not None:
+            filters += ";sort_season={}".format(sort_season)
         return self.get(
-            "league/{}/players;start={};count=25;status={}{}/percent_owned".
-            format(league_id, start, status, pos_parm))
+            "league/{}/players;{}/percent_owned".format(league_id, filters))
 
     def get_player_raw(self, league_id, search=None, ids=None):
         """Return the raw JSON when requesting player details


### PR DESCRIPTION
## Summary

`get_players_raw()` hardcoded `count=25` and offered no way to order the
returned players. Yahoo's `/players` collection accepts `sort`, `sort_type`,
`sort_season`, and `count` filters, but the library dropped them — so callers
who wanted Yahoo's own ranking (add-rank, owner-rank, or a per-stat sort,
optionally over a recent-form window like `lastweek`) had to bypass the library
and build the URL by hand.

This adds those filters:

- **`get_players_raw()`** gains `sort`, `sort_type`, `sort_season`, and
  `count` (default `25`).
- **`free_agents()`** and **`waivers()`** gain `sort` / `sort_type` /
  `sort_season`, threaded through `_fetch_players()`.

## Backward compatibility

Every new parameter defaults to `None` (`count` to `25`), so existing callers
are unaffected. With defaults, `get_players_raw()` builds a **byte-identical**
URL to before:

```
league/{id}/players;start=0;count=25;status=FA/percent_owned
```

The `free_agents` / `waivers` caches move from a `position` key to a
`(position, sort, sort_type, sort_season)` tuple key so sorted and unsorted
fetches don't clobber one another.

## Example

```python
# Top free-agent catchers by last week's home runs (stat_id 12)
lg.free_agents('C', sort='12', sort_type='lastweek')

# A bounded, add-rank-sorted raw page
lg.yhandler.get_players_raw(lg.league_id, 0, 'FA', sort='AR', count=10)
```

## Tests

- `test_get_players_raw` — URL construction for defaults, a position filter,
  and a full `sort` + `sort_type` + `sort_season` + `count` request.
- `test_free_agents_sorted` — the sort params flow through `free_agents()` and
  cache under a distinct key.

Full suite passes locally (`63 passed`).

## Notes / scope

- Left `taken_players()` unchanged — it has no position/sort surface today, and
  sorting a full-league fetch is meaningless.
- Scoped to the request filters only; the output subresource stays
  `percent_owned` (the `_players_from_page` parser depends on that adjacency),
  so this is purely additive.
- The `sort` / `sort_type` semantics come straight from Yahoo's live
  `/players` endpoint — I've been running exactly these filters (hand-built
  URLs) against a live league in an MCP server, which is what motivated
  upstreaming them. The added unit tests cover URL construction and plumbing;
  they don't hit Yahoo.
